### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -69,6 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: analyze-tags
     if: ${{ contains(inputs.IS_DEBOUNCED, 'false') || needs.analyze-tags.outputs.timestamp-diff > 604800 }} # 604800 equal one week.
+    permissions:
+      contents: read
     steps:
       - name: Checkout git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/dargmuesli/github-actions/security/code-scanning/5](https://github.com/dargmuesli/github-actions/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `schedule-release` job to explicitly define the required permissions for the `GITHUB_TOKEN`. Based on the workflow's operations, the `contents: read` permission is sufficient, as the job primarily checks out the repository and commits changes using a `PERSONAL_ACCESS_TOKEN`. This ensures that the `GITHUB_TOKEN` has minimal access, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
