### PR TITLE
fix(release-semantic): set permissions

### DIFF
--- a/.github/workflows/release-semantic.yml
+++ b/.github/workflows/release-semantic.yml
@@ -1,5 +1,9 @@
 name: 'Release: Semantic'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/dargmuesli/github-actions/security/code-scanning/4](https://github.com/dargmuesli/github-actions/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating comments or interacting with pull requests, if applicable.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `semantic-release` job to limit permissions specifically for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
