### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare_jobs
     if: needs.prepare_jobs.outputs.pr_found == 'false' || github.event_name == 'pull_request'
+    permissions:
+      contents: read
     steps:
       - name: Checkout git repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/dargmuesli/github-actions/security/code-scanning/2](https://github.com/dargmuesli/github-actions/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `actionlint` job. Since the job only involves linting and does not require write access, we will set the `contents` permission to `read`. This change ensures that the job has the minimal permissions necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
