### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   prepare_jobs:
     name: 'Prepare: job optimization'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       pr_found: ${{ steps.pr.outputs.pr_found }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/dargmuesli/github-actions/security/code-scanning/1](https://github.com/dargmuesli/github-actions/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `prepare_jobs` job. Since the job uses the `8BitJonny/gh-get-current-pr` action to fetch pull request information, it likely requires `contents: read` permission. This is the minimal permission needed to access repository contents. We will explicitly define this permission in the `permissions` block for the `prepare_jobs` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
