### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -23,6 +23,8 @@ jobs:
   analyze-tags:
     name: Analyze tags
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       previous-tag: ${{ steps.previoustag.outputs.tag }}
       timestamp-diff: ${{ steps.diff.outputs.timestamp-diff }}


### PR DESCRIPTION
Potential fix for [https://github.com/dargmuesli/github-actions/security/code-scanning/3](https://github.com/dargmuesli/github-actions/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `analyze-tags` job. This block will explicitly set the permissions required for the job to function correctly. Since the job only reads repository tags and timestamps, it likely only requires `contents: read` permissions. This change will ensure that the job does not have unnecessary write access or other elevated permissions.

The `permissions` block will be added directly under the `analyze-tags` job definition in the `.github/workflows/release-schedule.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
