### PR TITLE
chore(docker): remove deprecated build input

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,8 +51,6 @@ jobs:
       - name: Setup Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-        with:
-          install: true
 
       - name: Registry login
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request makes a minor update to the Docker workflow configuration. The change removes the `install: true` option from the `Setup Docker Buildx` step in the `.github/workflows/docker.yml` file.