### PR TITLE
feat(release-schedule): no commit

### DIFF
--- a/.github/workflows/release-schedule.yml
+++ b/.github/workflows/release-schedule.yml
@@ -7,11 +7,24 @@ on:
     - cron: '0 0 * * 3' # Every Wednesday at 00:00 AM UTC on the default branch
   workflow_call:
     inputs:
+      EXTRA_PLUGINS:
+        type: string
       GH_APP_ID:
         type: string
       IS_DEBOUNCED:
         default: ${{ github.event_name != 'workflow_dispatch' }}
         type: boolean
+      NODE_VERSION:
+        default: '22'
+        type: string
+      NODE_VERSION_FILE:
+        type: string
+      PACKAGE_MANAGER:
+        default: npm
+        type: string
+      RELEASE_AS:
+        default: patch
+        type: string
     secrets:
       GH_APP_PRIVATE_KEY:
         required: false
@@ -19,9 +32,22 @@ on:
         required: false
   workflow_dispatch:
     inputs:
+      EXTRA_PLUGINS:
+        type: string
       IS_DEBOUNCED:
         default: true
         type: boolean
+      NODE_VERSION:
+        default: '22'
+        type: string
+      NODE_VERSION_FILE:
+        type: string
+      PACKAGE_MANAGER:
+        default: npm
+        type: string
+      RELEASE_AS:
+        default: patch
+        type: string
 
 jobs:
   analyze-tags:
@@ -75,6 +101,9 @@ jobs:
     if: contains(inputs.IS_DEBOUNCED, 'false') || needs.analyze-tags.outputs.timestamp-diff > 604800 # 604800 equal one week.
     name: Schedule release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Create app token
         id: app-token
@@ -88,11 +117,45 @@ jobs:
       - name: Checkout git repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ steps.app-token.outputs.token || secrets.PERSONAL_ACCESS_TOKEN }} # will be used to push git commits too, allows to work around branch protection if the app is in the bypass list, and is required to trigger workflows on the new commit (https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs)
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token || secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
+      - name: Setup package manager
+        run: |
+          npm install -g corepack@latest
+          corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          commit_message: 'fix: schedule release'
-          commit_options: '--allow-empty'
-          skip_dirty_check: true
+          cache: ${{ inputs.PACKAGE_MANAGER }}
+          node-version: ${{ inputs.NODE_VERSION }}
+          node-version-file: ${{ inputs.NODE_VERSION_FILE }}
+
+      - name: Release (forced)
+        run: |
+          PACKAGES=" \
+            @semantic-release/changelog \
+            @semantic-release/commit-analyzer \
+            @semantic-release/exec \
+            @semantic-release/git \
+            @semantic-release/github \
+            @semantic-release/release-notes-generator \
+            conventional-changelog-conventionalcommits \
+            $EXTRA_PLUGINS \
+            semantic-release"
+          if [ "$PACKAGE_MANAGER" = "pnpm" ]; then
+            pnpm add --dev $PACKAGES
+            pnpm exec semantic-release --release-as "$RELEASE_AS"
+          elif [ "$PACKAGE_MANAGER" = "yarn" ]; then
+            yarn add -D $PACKAGES
+            yarn semantic-release --release-as "$RELEASE_AS"
+          else
+            npm install --save-dev $PACKAGES
+            npx semantic-release --release-as "$RELEASE_AS"
+          fi
+        env:
+          EXTRA_PLUGINS: ${{ inputs.EXTRA_PLUGINS }}
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || steps.app-token.outputs.token || github.token }}
+          PACKAGE_MANAGER: ${{ inputs.PACKAGE_MANAGER }}
+          RELEASE_AS: ${{ inputs.RELEASE_AS }}


### PR DESCRIPTION
This pull request updates the `release-schedule.yml` GitHub Actions workflow to add more flexibility and improve the release process. The main changes include adding new workflow inputs for Node.js and package manager configuration, updating the release job to use these inputs, switching to a direct semantic-release invocation instead of the auto-commit action, and enhancing permissions for the release job.

**Workflow configuration improvements:**

* Added new workflow inputs for `EXTRA_PLUGINS`, `NODE_VERSION`, `NODE_VERSION_FILE`, `PACKAGE_MANAGER`, and `RELEASE_AS` to both `workflow_call` and `workflow_dispatch`, allowing for more customizable release runs.

**Release job enhancements:**

* Set explicit `contents: write` and `id-token: write` permissions for the release job to ensure proper access for publishing and authentication.
* Updated the checkout step to use `fetch-depth: 0` for full history and clarified token usage.
* Added steps to set up the package manager and Node.js version based on workflow inputs, supporting `npm`, `pnpm`, and `yarn`.
* Replaced the use of `git-auto-commit-action` with a direct call to `semantic-release`, installing required plugins dynamically and supporting extra plugins and release type via inputs.