### PR TITLE
feat: improve package manager support

### DIFF
--- a/.github/workflows/browserslist-regex.yml
+++ b/.github/workflows/browserslist-regex.yml
@@ -52,9 +52,14 @@ jobs:
           token: ${{ steps.app-token.outputs.token || secrets.PERSONAL_ACCESS_TOKEN }} # will be used to push git commits too, allows to work around branch protection if the app is in the bypass list, and is required to trigger workflows on the new commit (https://github.com/stefanzweifel/git-auto-commit-action#commits-made-by-this-action-do-not-trigger-new-workflow-runs)
 
       - name: Setup package manager
+        if: inputs.PACKAGE_MANAGER != 'bun'
         run: |
           npm install -g corepack@latest
           corepack enable
+
+      - name: Setup bun
+        if: inputs.PACKAGE_MANAGER == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -90,8 +95,29 @@ jobs:
         shell: bash
         run: |
           set -e
+
+          run_bin() {
+            case "$PACKAGE_MANAGER" in
+              npm)    npx --no-install "$@" ;;
+              pnpm)   pnpm exec "$@" ;;
+              yarn)   yarn "$@" ;;
+              bun)    bunx "$@" ;;
+              *)      echo "Unsupported package manager: $PACKAGE_MANAGER" >&2; exit 1 ;;
+            esac
+          }
+
+          frozen_install() {
+            case "$PACKAGE_MANAGER" in
+              npm)    npm ci ;;
+              pnpm)   pnpm install --frozen-lockfile ;;
+              yarn)   yarn install --frozen-lockfile ;;
+              bun)    bun install --frozen-lockfile ;;
+              *)      echo "Unsupported package manager: $PACKAGE_MANAGER" >&2; exit 1 ;;
+            esac
+          }
+
           cd "$DIRECTORY"
-          "$PACKAGE_MANAGER" install --frozen-lockfile
+          frozen_install
 
           if [ "${{ steps.type.outputs.value }}" = "module" ]; then
             prefix="export default"
@@ -99,10 +125,10 @@ jobs:
             prefix="module.exports ="
           fi
 
-          echo "$prefix $("$PACKAGE_MANAGER" browserslist-useragent-regexp --allowHigherVersions);" > "$OUTPUT_PATH"
+          echo "$prefix $(run_bin browserslist-useragent-regexp --allowHigherVersions);" > "$OUTPUT_PATH"
 
           if [ -f "node_modules/.bin/eslint" ]; then
-            "$PACKAGE_MANAGER" eslint --fix "$OUTPUT_PATH"
+            run_bin eslint --fix "$OUTPUT_PATH"
           fi
 
       - name: Commit changes

--- a/.github/workflows/dargstack-rgen.yml
+++ b/.github/workflows/dargstack-rgen.yml
@@ -33,9 +33,14 @@ jobs:
           version: 1.0
 
       - name: Setup package manager
+        if: inputs.PACKAGE_MANAGER != 'bun'
         run: |
           npm install -g corepack@latest
           corepack enable
+
+      - name: Setup bun
+        if: inputs.PACKAGE_MANAGER == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -48,7 +53,15 @@ jobs:
         run: ${{ inputs.PACKAGE_MANAGER }} install
 
       - name: dargstack rgen
-        run: ${{ inputs.PACKAGE_MANAGER }} exec dargstack_rgen --validate
+        shell: bash
+        run: |
+          case "${{ inputs.PACKAGE_MANAGER }}" in
+            npm)    npx --no-install dargstack_rgen --validate ;;
+            pnpm)   pnpm exec dargstack_rgen --validate ;;
+            yarn)   yarn dargstack_rgen --validate ;;
+            bun)    bunx dargstack_rgen --validate ;;
+            *)      echo "Unsupported package manager: ${{ inputs.PACKAGE_MANAGER }}" >&2; exit 1 ;;
+          esac
 
       - name: dargstack derive
         run: |

--- a/.github/workflows/lock_file-maintenance.yml
+++ b/.github/workflows/lock_file-maintenance.yml
@@ -32,7 +32,7 @@ jobs:
             count=$((count + 1))
             pm="bun"
             path="bun.lockb"
-            install="bun install --lockfile-only"
+            install="bun install"
             found="${found:+$found, }bun.lockb"
           fi
 

--- a/.github/workflows/release-semantic.yml
+++ b/.github/workflows/release-semantic.yml
@@ -71,10 +71,14 @@ jobs:
           version: 1.0
 
       - name: Setup package manager
-        if: inputs.INSTALL_NODE_DEPENDENCIES || inputs.COREPACK_ENABLED
+        if: (inputs.INSTALL_NODE_DEPENDENCIES || inputs.COREPACK_ENABLED) && inputs.PACKAGE_MANAGER != 'bun'
         run: |
           npm install -g corepack@latest
           corepack enable
+
+      - name: Setup bun
+        if: (inputs.INSTALL_NODE_DEPENDENCIES || inputs.COREPACK_ENABLED) && inputs.PACKAGE_MANAGER == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Setup Node
         if: inputs.INSTALL_NODE_DEPENDENCIES
@@ -105,12 +109,11 @@ jobs:
       - name: Beautify changelog
         if: inputs.DRY_RUN == false && steps.semantic-release.outputs.new_release_published == 'true'
         run: |
-          if [ "${{ inputs.PACKAGE_MANAGER }}" = "pnpm" ]; then
-            pnpm dlx changelogithub
-          elif [ "${{ inputs.PACKAGE_MANAGER }}" = "yarn" ]; then
-            yarn dlx changelogithub
-          else
-            npx changelogithub
-          fi
+          case "${{ inputs.PACKAGE_MANAGER }}" in
+            pnpm)   pnpm dlx changelogithub ;;
+            yarn)   yarn dlx changelogithub ;;
+            bun)    bunx changelogithub ;;
+            *)      npx changelogithub ;;
+          esac
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The changes introduce improvements to how GitHub Actions workflows handle different Node.js package managers, especially Bun.

*   **Adds explicit Bun setup**: Introduces a dedicated setup step for Bun to ensure its correct installation and availability when specified as the package manager.
*   **Standardizes command execution**: Implements shell functions and `case` statements to abstract and normalize the way package manager-specific commands (like running binaries or performing frozen installs) are executed across various workflows.
*   **Improves Bun integration**: Adjusts Bun's install command for lockfile maintenance and ensures consistent behavior for Bun in all relevant workflow steps.