### PR TITLE
fix(docker): fetch lfs objects during checkout

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # fetch all history for all branches and tags
+          lfs: true
           token: ${{ steps.app-token.outputs.token || secrets.PERSONAL_ACCESS_TOKEN || github.token }}
 
       - name: Setup Docker Buildx


### PR DESCRIPTION
actions/checkout does not fetch Git LFS content by default, so consuming repositories that track files with LFS end up building against pointer files instead of the real content.