### PR TITLE
fix(release-semantic): pin conventional-changelog-conventionalcommits to v9

### DIFF
--- a/.github/workflows/release-semantic.yml
+++ b/.github/workflows/release-semantic.yml
@@ -101,7 +101,7 @@ jobs:
             @semantic-release/changelog
             @semantic-release/exec
             @semantic-release/git
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@9 # v10 requires conventional-changelog-writer@9+, newer than what @semantic-release/release-notes-generator currently bundles
             ${{ inputs.EXTRA_PLUGINS }}
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN || steps.app-token.outputs.token }} # required to create releases & comments on behalf of a custom user


### PR DESCRIPTION
conventional-changelog-conventionalcommits@10 added a compatibility check requiring conventional-changelog-writer@9+, but @semantic-release/release-notes-generator and @semantic-release/commit-analyzer still depend on conventional-changelog-writer@^8.0.0. Since extra_plugins pulled the preset unpinned, it always resolved to the latest 10.x, which throws against the older writer actually loaded. Pinning to the last 9.x release restores compatibility.